### PR TITLE
Bypass windows.h min/max macro

### DIFF
--- a/zip_file.hpp
+++ b/zip_file.hpp
@@ -5621,7 +5621,7 @@ private:
     {
         if(!comment.empty())
         {
-            auto comment_length = std::min(static_cast<uint16_t>(comment.length()), std::numeric_limits<uint16_t>::max());
+            auto comment_length = (std::min)(static_cast<uint16_t>(comment.length()), (std::numeric_limits<uint16_t>::max)());
             buffer_[buffer_.size() - 2] = static_cast<char>(comment_length);
             buffer_[buffer_.size() - 1] = static_cast<char>(comment_length >> 8);
             std::copy(comment.begin(), comment.end(), std::back_inserter(buffer_));


### PR DESCRIPTION
Code from :

 Jerem584(https://github.com/Jerem584)
 Bypass windows.h min/max macro https://github.com/tfussell/miniz-cpp/pull/20

Based of code by:
[tfussell](https://github.com/tfussell)